### PR TITLE
fix(stock): Correct the condition checking negative stock

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,7 +61,7 @@ const applyStockChange = async (stock) => {
   if (product.attributes.stock_available + changeStock < 0) throw new Error('negative stock')
 
   const data = {
-    available_stock: product.attributes.stock_available + changeStock,
+    stock_available: product.attributes.stock_available + changeStock,
   }
 
   console.log(JSON.stringify({ data }))

--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ const applyStockChange = async (stock) => {
 
   const changeStock = (stock.type === 'IN' ? 1 : -1) * stock.amount
 
-  if (changeStock < 0) throw new Error('negative stock')
+  if (product.attributes.stock_available + changeStock < 0) throw new Error('negative stock')
 
   const data = {
     available_stock: product.attributes.stock_available + changeStock,


### PR DESCRIPTION
Currently, if `changeStock` is under `0` (which can happens when reducing stock), an error in thrown, even if the total stock would be above `0`. This error occures because the condition is not checking the current stock before calculating. This is a patch for that.